### PR TITLE
Window Load Fix

### DIFF
--- a/responsible-height.js
+++ b/responsible-height.js
@@ -57,7 +57,7 @@
 				//If the user chooses run resize function constantly during resize
 				resize();
 			} else {
-				//Only run the plugin options delay milliseconds after the resize ha been last called
+				//Only run the plugin options delay milliseconds after the resize has been last called
 				clearTimeout(resizeId);
 				resizeId = setTimeout(function(){
 					resize();
@@ -66,7 +66,7 @@
 		});
 
 		//run the resize once upon creation
-		resize();
+		$(window).on('load', resize);
 
 		/* ==========================================================================
 		 Functions
@@ -146,7 +146,7 @@
 
 			self.each(function ( index ) {
 				debug(index);
-				//Fet the element whose size we will be controlling
+				//Get the element whose size we will be controlling
 				var element = get_element( self.eq(index) );
 				//Set col to the current column
 				col++;


### PR DESCRIPTION
Seem to have fixed an issue where it failed to size correctly when all
images haven’t loaded within resized elements, added a window.load
handler. Hopefully fixed it. Caught a couple of typos too.
